### PR TITLE
chore: migrate deprecated mongodb node driver options

### DIFF
--- a/mern/server/db/conn.js
+++ b/mern/server/db/conn.js
@@ -2,8 +2,8 @@
 const { MongoClient } = require("mongodb");
 const Db = process.env.ATLAS_URI;
 const client = new MongoClient(Db, {
-  useNewUrlParser: true,
-  useUnifiedTopology: true,
+  
+  
 });
 
 var _db;
@@ -23,5 +23,4 @@ module.exports = {
 
   getDb: function () {
     return _db;
-  },
-};
+  }};


### PR DESCRIPTION
## Summary
- remove deprecated mongodb node driver options:
  - useNewUrlParser / usenewurlparser
  - useUnifiedTopology / useunifiedtopology
  - reconnectTries
  - reconnectInterval
- rename poolSize / poolsize to maxPoolSize where applicable

## Validation
- syntax checks passed for modified source files
- lint/build/test verification was executed where scripts were available
- remaining failures are pre-existing test/env issues unrelated to this migration

## Notes
- this PR is part of a repo-wide migration sweep to align examples and apps with current mongodb driver behavior
